### PR TITLE
Protobuf builders only internally

### DIFF
--- a/importers/src/main/java/pl/edu/icm/coansys/importers/MetadataPBParser.java
+++ b/importers/src/main/java/pl/edu/icm/coansys/importers/MetadataPBParser.java
@@ -228,7 +228,7 @@ public class MetadataPBParser {
         return doc;
     }
 
-    public static DocumentMetadata yelementToDocumentMetadata(YElement yElement) {
+    public static DocumentMetadata yelementToDocumentMetadata(YElement yElement, String collection) {
         YStructure struct = yElement.getStructure(YaddaIdConstants.ID_HIERARACHY_JOURNAL);
         if (struct == null || !YaddaIdConstants.ID_LEVEL_JOURNAL_ARTICLE.equals(struct.getCurrent().getLevel())) {
             return null;
@@ -346,11 +346,13 @@ public class MetadataPBParser {
         }
 
         docBuilder.addAllReference(references);
+        
+        docBuilder.setCollection(collection);
 
         return docBuilder.build();
     }
 
-    public static List<DocumentMetadata> parseStream(InputStream stream, MetadataType type) {
+    public static List<DocumentMetadata> parseStream(InputStream stream, MetadataType type, String collection) {
         List<DocumentMetadata> results = new ArrayList<DocumentMetadata>();
 
         try {
@@ -358,7 +360,7 @@ public class MetadataPBParser {
             if (elem != null) {
                 for (YExportable yExportable : elem) {
                     if (yExportable instanceof YElement) {
-                        DocumentMetadata doc = yelementToDocumentMetadata((YElement) yExportable);
+                        DocumentMetadata doc = yelementToDocumentMetadata((YElement) yExportable, collection);
                         if (doc != null) {
                             results.add(doc);
                         }

--- a/importers/src/main/java/pl/edu/icm/coansys/importers/ZipDirToProtos.java
+++ b/importers/src/main/java/pl/edu/icm/coansys/importers/ZipDirToProtos.java
@@ -36,6 +36,7 @@ public class ZipDirToProtos implements Iterable<Document> {
      */
 
     private static final Logger logger = LoggerFactory.getLogger(ZipDirToProtos.class);
+    private String collection;
     //List of zip files to process and actual position in this list
     private File[] listZipFiles;
     private int zipIndex;
@@ -47,7 +48,8 @@ public class ZipDirToProtos implements Iterable<Document> {
     //An object which will be returned by next call of iterators next() method
     private Document nextItem = null;
 
-    public ZipDirToProtos(String zipDirPath) {
+    public ZipDirToProtos(String zipDirPath, String collection) {
+        this.collection = collection;
         File zipDir = new File(zipDirPath);
         if (zipDir.isDirectory()) {
             listZipFiles = zipDir.listFiles(new ZipFilter());
@@ -115,7 +117,7 @@ public class ZipDirToProtos implements Iterable<Document> {
             if (yExportable instanceof YElement) {
                 YElement yElement = (YElement) yExportable;
 
-                DocumentMetadata docMetadata = MetadataPBParser.yelementToDocumentMetadata(yElement);
+                DocumentMetadata docMetadata = MetadataPBParser.yelementToDocumentMetadata(yElement, collection);
                 
                 if (docMetadata != null) {
                     docBuilder = Document.newBuilder();
@@ -146,7 +148,7 @@ public class ZipDirToProtos implements Iterable<Document> {
                                                 pdfIS = actualZipArchive.getFileAsInputStream(foundPaths.get(0));
                                                 // ... do something with pdfIS
                                                 Media.Builder mediaBuilder = Media.newBuilder();
-                                                mediaBuilder.setKey(nextItem.getKey()); //Media and Document should have the same key?
+                                                mediaBuilder.setKey(docBuilder.getKey()); //Media and Document should have the same key?
                                                 mediaBuilder.setMediaType("PDF"); //??
                                                 mediaBuilder.setContent(ByteString.copyFrom(IOUtils.toByteArray(pdfIS)));
                                                 docBuilder.addMedia(mediaBuilder.build());

--- a/importers/src/test/java/pl/edu/icm/coansys/importers/ZipDirToProtosTest.java
+++ b/importers/src/test/java/pl/edu/icm/coansys/importers/ZipDirToProtosTest.java
@@ -2,6 +2,7 @@ package pl.edu.icm.coansys.importers;
 
 import org.junit.Test;
 import pl.edu.icm.coansys.importers.DocumentProtos.Document;
+import static org.junit.Assert.*;
 
 /**
  *
@@ -12,12 +13,13 @@ public class ZipDirToProtosTest {
     //@Test
     public void readZipDirTest() {
         String zipDirPath = this.getClass().getClassLoader().getResource("zipdir").getPath();
-        ZipDirToProtos zdtp = new ZipDirToProtos(zipDirPath);
+        ZipDirToProtos zdtp = new ZipDirToProtos(zipDirPath, "TEST_COLLECTION");
         
         int counter = 0;
         for (Document doc : zdtp) {
             System.out.println("counter: " + counter++);
-            System.out.println("builder: " + doc.toString());
+            System.out.println("doc: " + doc.toString());
+            assertEquals(doc.getMetadata().getCollection(), "TEST_COLLECTION");
         }
     }
 }


### PR DESCRIPTION
Protocol buffer builders should only be used to build a message, not to be sent elsewhere. I've changed interfaces of our classes to use message types, not builders. Builders are used only internally.
