### PR TITLE
Ignore pig temporary files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@
 /logs-analysis/target/
 /target/
 /integration/target/
+
+#pig temp files
+*.crc
+*part-r-00000
+_SUCCESS


### PR DESCRIPTION
The change in the .gitignore file should make Git ignore pig temporary files. They used to be added accidentally and this is to be avoided
