### PR TITLE
Fixed problem with OAI-PMH import

### DIFF
--- a/importers/src/main/java/pl/edu/icm/coansys/importers/iterators/OAIPMHDirToDocumentDTOIterator.java
+++ b/importers/src/main/java/pl/edu/icm/coansys/importers/iterators/OAIPMHDirToDocumentDTOIterator.java
@@ -131,6 +131,8 @@ public class OAIPMHDirToDocumentDTOIterator implements Iterable<DocumentDTO> {
             String str;
             try {
                 item.setAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
+                item.setAttribute("xmlns:dc", "http://purl.org/dc/elements/1.1/");
+                item.setAttribute("xmlns:oai_dc", "http://www.openarchives.org/OAI/2.0/oai_dc/");
                 str = nodeToXmlString(item);
                 List<DocumentMetadata> docs = MetadataToProtoMetadataParser.parseStream(new ByteArrayInputStream(str.getBytes("UTF-8")),
                         MetadataToProtoMetadataParser.MetadataType.OAI_DC, collection);


### PR DESCRIPTION
There was a problem with import some OAI-PMH data -- incorrect namespaces. These namespaces are now hardcoded.
