### PR TITLE
Changed address of test cluster

### DIFF
--- a/logs-analysis/logs-analysis-workflow/src/test/resources/configIT/env/IT-env-testcluster.properties
+++ b/logs-analysis/logs-analysis-workflow/src/test/resources/configIT/env/IT-env-testcluster.properties
@@ -1,7 +1,7 @@
-oozieServiceURI=http://hadoop-ci-test.vls.icm.edu.pl:11000/oozie/
-nameNode=hadoop-ci-test.vls.icm.edu.pl:8020
+oozieServiceURI=http://hadoop-ci-test4.vls.icm.edu.pl:11000/oozie/
+nameNode=hadoop-ci-test4.vls.icm.edu.pl:8020
 queueName=default
-jobTracker=hadoop-ci-test.vls.icm.edu.pl:8021
+jobTracker=hadoop-ci-test4.vls.icm.edu.pl:8021
 hdfsUserName=coansys
 hdfsWorkingDirURI=hdfs://${nameNode}/user/${hdfsUserName}/IT-${wfName}/
 wfName=logs-analysis


### PR DESCRIPTION
New address (hadoop-ci-test4) is compatible with nat64 which is needed to resolve problems with IPv6
