### PR TITLE
Removed dependency of bwmeta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <protobuf.java.version>2.4.1</protobuf.java.version>
         <testng.version>6.5.2</testng.version>
         <maven.surefire.plugin.version>2.12.3</maven.surefire.plugin.version>
-        <bwmeta.version>2.2.0</bwmeta.version>
         <spring.version>3.2.0.RELEASE</spring.version>
         <oozie-maven-plugin.version>1.1-SNAPSHOT</oozie-maven-plugin.version>
         <oozie-runner.version>1.1-SNAPSHOT</oozie-runner.version>
@@ -219,11 +218,6 @@
             <version>${testng.version}</version>
             <scope>test</scope>
             <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>pl.edu.icm.bwmeta</groupId>
-            <artifactId>bwmeta</artifactId>
-            <version>${bwmeta.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Dependency of bwmeta is no longer needed after moving importers to coansys-io
