### PR TITLE
Quick Fix for build failures

### DIFF
--- a/document-classification/dc-model-building-workflow/src/main/oozie/workflow.xml
+++ b/document-classification/dc-model-building-workflow/src/main/oozie/workflow.xml
@@ -1,0 +1,1 @@
+<!--workflow stub-->


### PR DESCRIPTION
Fake workflow file in dc-model-building-workflow to satisfy oozie-maven-plugin
