### PR TITLE
Updated types in disambiguation-work workflow; updated paths

### DIFF
--- a/disambiguation-work/disambiguation-work-workflow/src/main/oozie/workflow.xml
+++ b/disambiguation-work/disambiguation-work-workflow/src/main/oozie/workflow.xml
@@ -16,11 +16,11 @@
 				</property>
 				<property>
 					<name>mapred.input.dir</name>
-					<value>${workingDir}/hbase-sf-out/</value>
+					<value>${inputSeqFile}</value>
 				</property>
 				<property>
 					<name>mapred.output.dir</name>
-					<value>${workingDir}/dis-work-out/</value>
+					<value>${outputSeqFile}</value>
 				</property>
 				<property>
 					<name>mapreduce.map.class</name>
@@ -53,12 +53,20 @@
 					</value>
 				</property>
 				<property>
+					<name>mapred.mapoutput.key.class</name>
+					<value>org.apache.hadoop.io.Text</value>
+				</property>
+				<property>
+					<name>mapred.mapoutput.value.class</name>
+					<value>org.apache.hadoop.io.BytesWritable</value>
+				</property>
+				<property>
 					<name>mapred.output.key.class</name>
 					<value>org.apache.hadoop.io.Text</value>
 				</property>
 				<property>
 					<name>mapred.output.value.class</name>
-					<value>org.apache.hadoop.io.BytesWritable</value>
+					<value>org.apache.hadoop.io.Text</value>
 				</property>
 				<property>
 					<name>diMapApplicationContextPath</name>


### PR DESCRIPTION
Data types in disambiguation-work workflow have to be updated after changes in disambiguation-work module. 
Input and output data paths changed because of wofkflow reorganisation.
