### PR TITLE
DocSim Uberworkflow is immune to outer configuration changes

### DIFF
--- a/document-similarity/document-similarity-oap-uberworkflow/src/main/oozie/workflow.xml
+++ b/document-similarity/document-similarity-oap-uberworkflow/src/main/oozie/workflow.xml
@@ -53,6 +53,10 @@
 			<name>finalOutputPathGlobal</name>
 			<value>${ds_similarityOutputPath}/final/</value>
 		</property>
+		<property>
+			<name>ds_serialize_to_proto</name>
+			<value>false</value>
+		</property>
 	</parameters>
 
 	<global>


### PR DESCRIPTION
in doc-sim-oap-uber oozie.wf.subworkflow.classpath.inheritance=true
default param for docsim-uberworkflow: ds_serialize_to_proto=false
