### PR TITLE
Fix XML well-formedness errors in two workflow definitions

### DIFF
--- a/document-similarity/document-similarity-oap-demo-workflow/src/main/oozie/workflow-splited.xml
+++ b/document-similarity/document-similarity-oap-demo-workflow/src/main/oozie/workflow-splited.xml
@@ -28,6 +28,7 @@
     </action>
 
     <action name='pairwise-sim'>
+        <pig>
             <job-tracker>${jobTracker}</job-tracker>
             <name-node>${nameNode}</name-node>
             <configuration>

--- a/document-similarity/document-similarity-workflow/src/main/oozie/workflow-splited.xml
+++ b/document-similarity/document-similarity-workflow/src/main/oozie/workflow-splited.xml
@@ -28,6 +28,7 @@
     </action>
 
     <action name='pairwise-sim'>
+        <pig>
             <job-tracker>${jobTracker}</job-tracker>
             <name-node>${nameNode}</name-node>
             <configuration>


### PR DESCRIPTION
Eclipse shouted at me, now it doesn't.
