### PR TITLE
Set parent for models submodule

### DIFF
--- a/models/pom.xml
+++ b/models/pom.xml
@@ -2,12 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>pl.edu.icm.coansys</groupId>
+        <artifactId>coansys</artifactId>
+        <version>1.10-final-SNAPSHOT</version>
+    </parent>
     <name>Models</name>
     <description>Models used in CoAnSys</description>
-
-    <groupId>pl.edu.icm.coansys</groupId>
     <artifactId>models</artifactId>
-    <version>1.10-final-SNAPSHOT</version> 
 
     <properties>
         <protobuf.java.version>2.5.0</protobuf.java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
         <testng.version>6.5.2</testng.version>
         <maven.surefire.plugin.version>2.12.3</maven.surefire.plugin.version>
         <spring.version>4.1.5.RELEASE</spring.version>
-        <oozie-maven-plugin.version>1.6-SNAPSHOT</oozie-maven-plugin.version>
-        <oozie-runner.version>1.5-SNAPSHOT</oozie-runner.version>
+        <oozie-maven-plugin.version>1.6</oozie-maven-plugin.version>
+        <oozie-runner.version>1.5</oozie-runner.version>
         <jackson-mapper-asl.version>1.9.12</jackson-mapper-asl.version>
         <scala.version>2.10.6</scala.version>
         <scala.binary.version>2.10</scala.binary.version>


### PR DESCRIPTION
Setting parent in all modules will simplify releases. After reorganizing dependencies much time ago there is no reason to avoid this.