### PR TITLE
Closes #434: Fix timeout issue during the sim1_postprocess_s1_e1_filter_input phase

### DIFF
--- a/document-similarity/document-similarity-logic/src/main/pig/sim1-postprocess-s1-e1-filter-sims.pig
+++ b/document-similarity/document-similarity-logic/src/main/pig/sim1-postprocess-s1-e1-filter-sims.pig
@@ -19,6 +19,7 @@
 %default parallel 10
 %default tmpCompressionCodec gz
 %default mapredChildJavaOpts -Xmx8000m
+%default mapreduceTaskTimeout 7200000
 
 %default jars '*.jar'
 %default commonJarsPath '../../../../document-similarity-workflow/target/oozie-wf/lib/$jars'
@@ -29,6 +30,7 @@ SET default_parallel $parallel
 SET mapred.child.java.opts $mapredChildJavaOpts
 SET mapreduce.map.java.opts $mapredChildJavaOpts
 SET mapreduce.reduce.java.opts $mapredChildJavaOpts
+SET mapreduce.task.timeout $mapreduceTaskTimeout
 SET pig.tmpfilecompression true
 SET pig.tmpfilecompression.codec $tmpCompressionCodec
 %DEFAULT scheduler default


### PR DESCRIPTION
Setting `mapreduce.task.timeout` value to `7200000` in `sim1-postprocess-s1-e1-filter-sims.pig`.